### PR TITLE
Fix constant typo and update pre-release sorting

### DIFF
--- a/tasks/versionProcessor/versionProcessor.js
+++ b/tasks/versionProcessor/versionProcessor.js
@@ -266,7 +266,7 @@ function fetchOutdated(task, options) {
               patch: 1,
               minor: 2,
               major: 3,
-              preRelease: 4,
+              'pre-release': 4,
               unknown: 5,
             }
             const aType = categorizeVersionJump(a.current, a.latest)

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -7,7 +7,7 @@ export const MAIN_TITLE = `
 ╚═╝     ╚═╝  ╚═╝   ╚═╝    ╚═════╝╚═╝  ╚═╝ ╚══╝╚══╝  ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝
 `
 
-export const UNKNOWN = 'UNKOWN'
+export const UNKNOWN = 'UNKNOWN'
 
 export const SKIPPED = 'SKIPPED'
 


### PR DESCRIPTION
## Summary
- correct typo in `UNKNOWN` constant
- use hyphenated `pre-release` sort key to match other checks

## Testing
- `npm test` *(fails: No tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dc9339d9083229225b5efe122d29a