### PR TITLE
Fix ALL constant import

### DIFF
--- a/reports/generateReports.js
+++ b/reports/generateReports.js
@@ -3,7 +3,7 @@ import logger from './logger.js'
 import fs from 'fs'
 import fsPromises from 'fs/promises'
 import { UNKNOWN } from '../utils/constants.js'
-import { ALL } from 'dns'
+import { ALL } from '../utils/constants.js'
 import tar from 'tar-stream'
 import path from 'path'
 


### PR DESCRIPTION
## Summary
- use `ALL` from `utils/constants.js` in `generateReports.js`

## Testing
- `npm test` *(fails: No tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dcec3d19c83228ce22ad71e19c723