### PR TITLE
Fix typo for invalid package metadata

### DIFF
--- a/tasks/versionProcessor/fetchMetadata.js
+++ b/tasks/versionProcessor/fetchMetadata.js
@@ -185,7 +185,7 @@ export async function processPackagesMetadata(packages) {
           results.valid[pkg] = { ...info, ...metadata }
         } else {
           results.invalid[pkg] = {
-            valiationStatus: 'FAILED VALIDATION',
+            validationStatus: 'FAILED VALIDATION',
             ...info,
             ...metadata,
           }


### PR DESCRIPTION
## Summary
- fix typo in `fetchMetadata.js` so invalid packages use `validationStatus` key

## Testing
- `npm test` *(fails: No tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_684eca1257d08322a86ae9ae499818b7