### PR TITLE
Update to version 0.0.02

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Patchworks (0.0.02-Alpha)
+# Patchworks (0.0.02)
 
 ![Patchworks Logo](https://github.com/shanemiller89/patchworks/blob/main/assets/patchworks_title.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "patchworks",
-  "version": "0.0.01",
+  "version": "0.0.02",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "patchworks",
-      "version": "0.0.01",
+      "version": "0.0.02",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchworks",
-  "version": "0.0.01",
+  "version": "0.0.02",
   "repository": {
     "type": "git",
     "url": "https://github.com/shanemiller89/patchworks.git"


### PR DESCRIPTION
## Summary
- bump version to `0.0.02` in `package.json` and lockfile
- synchronize README heading and CLI `.version()` call

## Testing
- `npm test` *(fails: No tests specified)*
- `npm run build` *(fails: babel not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f92772a7c8322a7e7210e8618a67e