### PR TITLE
Fix install option name

### DIFF
--- a/menus/mainMenu.js
+++ b/menus/mainMenu.js
@@ -24,7 +24,7 @@ export async function renderMainMenu(options) {
     levelScope = options.levelScope || config.levelScope || 'strict',
     summary = options.summary || config.summary || false,
     showExcluded = options.showExcluded || config.showExcluded || false,
-    installUpdates = options.install || config.install || true,
+    install = options.install || config.install || true,
   } = options
 
   let selectedIndex = 0
@@ -75,8 +75,8 @@ ${chalk.blue(SINGLE_LINE)}
   ${chalk.white('☒')} ${chalk.gray.bold('Show Excluded:')}              ${
       showExcluded ? chalk.green('Enabled') : chalk.red('Disabled')
     }
-  ${chalk.white('♨')} ${chalk.gray.bold('Install Updates:')}            ${
-      installUpdates ? chalk.green('Enabled') : chalk.red('Disabled')
+  ${chalk.white('♨')} ${chalk.gray.bold('Install Dependencies:')}            ${
+      install ? chalk.green('Enabled') : chalk.red('Disabled')
     }
 ${chalk.blue(DOUBLE_LINE)}
   `
@@ -216,7 +216,7 @@ ${chalk.blue(DOUBLE_LINE)}
             levelScope,
             summary,
             showExcluded,
-            installUpdates,
+              install,
           }).then(() => {
             process.exit(0)
           })
@@ -237,7 +237,7 @@ ${chalk.blue(DOUBLE_LINE)}
             levelScope,
             summary,
             showExcluded,
-            installUpdates,
+              install,
           }).then(() => {
             process.exit(0)
           })


### PR DESCRIPTION
## Summary
- rename the `installUpdates` option to `install`
- update main menu text for install setting

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f926f1380832291c56227008281e5