### PR TITLE
Add Jest test for CLI export

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+export default {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.js$': 'babel-jest',
+  },
+};

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -1,0 +1,13 @@
+jest.mock('../cli/commands/update.js', () => ({}), { virtual: true });
+jest.mock('../cli/commands/reports.js', () => ({}), { virtual: true });
+jest.mock('../cli/commands/menu.js', () => ({}), { virtual: true });
+jest.mock('chalk', () => ({}));
+jest.mock('commander', () => ({}));
+
+import cli from '../cli/index.js';
+
+describe('CLI entry', () => {
+  test('exports a function', () => {
+    expect(typeof cli).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with `babel-jest`
- keep Babel's `ignore` option so node modules are not transformed
- add test ensuring CLI entry exports a function

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850358bcfc88322ae8d2bed2113c6d1