### PR TITLE
Enable CLI TypeScript build output for runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "patchworks",
   "version": "0.1.0",
   "description": "A CLI tool to manage dependency updates by semantic versioning, breaking change detection, and batch selection for efficient prioritization",
-  "main": "src/cli/index.ts",
+  "main": "src/cli/index.js",
   "bin": {
-    "patchworks": "./bin/patchworks.ts"
+    "patchworks": "./bin/patchworks.js"
   },
   "files": [
     "bin/",
@@ -21,7 +21,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "npm run build && jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lint": "eslint -c .eslintrc.json \"src/**/*.js\" \"analysis/**/*.js\" \"config/**/*.js\" \"menus/**/*.js\" \"prompts/**/*.js\" \"reports/**/*.js\" \"tasks/**/*.js\" \"utils/**/*.js\" \"versionLogs/**/*.js\"",
@@ -29,8 +29,9 @@
     "format": "prettier --write \"src/**/*.js\" \"analysis/**/*.js\" \"config/**/*.js\" \"menus/**/*.js\" \"prompts/**/*.js\" \"reports/**/*.js\" \"tasks/**/*.js\" \"utils/**/*.js\" \"versionLogs/**/*.js\"",
     "type-check": "tsc --noEmit",
     "type-check:watch": "tsc --noEmit --watch",
-    "build": "tsc",
-    "prepare": "chmod +x bin/patchworks.js",
+    "build": "tsc -p tsconfig.build.json",
+    "postbuild": "chmod +x bin/patchworks.js",
+    "prepare": "npm run build",
     "pre-publish": "./scripts/pre-publish.sh",
     "prepublishOnly": "./scripts/pre-publish.sh && npm run lint && npm run type-check && npm test",
     "local:install": "npm link",

--- a/prompts/baseToggle.ts
+++ b/prompts/baseToggle.ts
@@ -4,6 +4,7 @@ import {
   useKeypress,
   usePrefix,
   useState,
+  type KeypressEvent,
 } from '@inquirer/core'
 import chalk from 'chalk'
 
@@ -12,11 +13,6 @@ export interface ToggleConfig {
   active?: string
   inactive?: string
   default?: boolean
-}
-
-export interface KeyEvent {
-  name: string
-  [key: string]: any
 }
 
 // Define a custom toggle prompt
@@ -30,7 +26,7 @@ export const customTogglePrompt = createPrompt<boolean, ToggleConfig>((config, d
   const prefix = usePrefix({ status })
 
   // Handle keypress events
-  useKeypress((key: KeyEvent) => {
+  useKeypress((key: KeypressEvent) => {
     if (isEnterKey(key)) {
       setStatus('done')
       done(value === activeLabel)

--- a/scripts/pre-publish.sh
+++ b/scripts/pre-publish.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
+set -euo pipefail
+
 echo "🧪 Testing Patchworks CLI Package"
+
+echo "🛠️ Building CLI entry points..."
+npm run build
 
 # 1. Test the bin file directly first
 echo "1️⃣ Testing bin file directly..."
-if ./bin/patchworks.js --help; then
+if node ./bin/patchworks.js --help; then
     echo "✅ Bin file works directly"
 else
     echo "❌ Bin file fails - check permissions and shebang"

--- a/src/__tests__/cli.test.js
+++ b/src/__tests__/cli.test.js
@@ -1,3 +1,5 @@
+const { spawnSync } = require('child_process');
+
 describe('CLI module structure', () => {
   test('CLI module exists and has correct structure', () => {
     // Test that the CLI module can be required
@@ -13,13 +15,25 @@ describe('CLI module structure', () => {
     const path = require('path');
     const fs = require('fs');
     const binPath = path.join(__dirname, '../../bin/patchworks.js');
-    
+
     expect(fs.existsSync(binPath)).toBe(true);
-    
+
     const stats = fs.statSync(binPath);
     expect(stats.isFile()).toBe(true);
     // Check if file has execute permissions
     expect(stats.mode & parseInt('111', 8)).toBeGreaterThan(0);
+  });
+
+  test('binary starts without syntax errors', () => {
+    const path = require('path');
+    const binPath = path.join(__dirname, '../../bin/patchworks.js');
+
+    const result = spawnSync('node', [binPath, '--help'], {
+      encoding: 'utf8',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
   });
 
   test('package.json has correct configuration', () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -175,6 +175,7 @@ export default function (): void {
         summary: options.summary || config?.summary || false,
         skipped: options.skipped || config?.skipped || false,
         write: options.write || config?.write || false,
+        install: options.install || config?.install || false,
         excludeRepoless:
           options.excludeRepoless || config?.excludeRepoless || false,
         debug: options.debug || config?.debug || false,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./",
+    "rootDir": "./",
+    "declaration": false,
+    "emitDeclarationOnly": false
+  },
+  "include": [
+    "bin/**/*.ts",
+    "config/**/*.ts",
+    "menus/**/*.ts",
+    "prompts/**/*.ts",
+    "reports/**/*.ts",
+    "src/**/*.ts",
+    "tasks/**/*.ts",
+    "utils/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a dedicated build configuration that emits JavaScript for the CLI entry points
- point package metadata and scripts at the compiled JavaScript and ensure the pre-publish workflow builds before exercising the binary
- extend the CLI tests to execute the generated binary and resolve type issues uncovered by the new build

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e544dd245c832293d81c5599d059c8