### PR TITLE
Fix install flag handling in CLI and menu

### DIFF
--- a/menus/mainMenu.ts
+++ b/menus/mainMenu.ts
@@ -39,7 +39,7 @@ export async function renderMainMenu(options: MenuOptions): Promise<void> {
     levelScope = options.levelScope || config?.levelScope || 'strict',
     summary = options.summary || config?.summary || false,
     showExcluded = options.showExcluded || config?.showExcluded || false,
-    install = options.install || config?.install || true,
+    install = options.install ?? config?.install ?? false,
   } = options
 
   let selectedIndex: number = 0

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -138,7 +138,7 @@ export default function (): void {
         summary: options.summary || config?.summary || false,
         skipped: options.skipped || config?.skipped || false,
         write: options.write || config?.write || false,
-        install: options.install || config?.install || true,
+        install: options.install ?? config?.install ?? false,
         excludeRepoless:
           options.excludeRepoless || config?.excludeRepoless || false,
         debug: options.debug || config?.debug || false,
@@ -214,7 +214,7 @@ export default function (): void {
         summary: options.summary || config?.summary || false,
         skipped: options.skipped || config?.skipped || false,
         write: options.write || config?.write || false,
-        install: options.install || config?.install || true,
+        install: options.install ?? config?.install ?? false,
         excludeRepoless:
           options.excludeRepoless || config?.excludeRepoless || false,
         debug: options.debug || config?.debug || false,


### PR DESCRIPTION
## Summary
- preserve explicit false values for the install flag in CLI menu and update commands
- mirror the install flag handling in the interactive menu so the display matches the effective state

## Testing
- npm test *(fails: existing suite expects compiled JS artifacts such as src/cli/index.js and bin/patchworks.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e544ec49588322ba4fb0bdc8bb5c57